### PR TITLE
Update PrecisionFarmingAddon.lua

### DIFF
--- a/src/PrecisionFarmingAddon.lua
+++ b/src/PrecisionFarmingAddon.lua
@@ -26,7 +26,7 @@ PrecisionFarmingAddon.modules = {
         name = "geologist",
         filename = "geologistModule",
         object = "GeologistModule",
-        requiredVersion = "1.0.2.0"
+        requiredVersion = "1.0.2.1"
     }
 }
 


### PR DESCRIPTION
Adapted to current version of Precision Farming DLC. This makes the geologist work again.